### PR TITLE
feat: switch image generation model from Replicate to NanoBanana

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,6 +5,7 @@ load_dotenv()
 
 BOT_TOKEN = os.getenv("BOT_TOKEN")
 REPLICATE_TOKEN = os.getenv("REPLICATE_API_TOKEN")
+NANO_BANANA_API_KEY = os.getenv("NANO_BANANA_API_KEY")
 
 if not BOT_TOKEN or not REPLICATE_TOKEN:
     raise RuntimeError("❌ BOT_TOKEN или REPLICATE_API_TOKEN не установлен")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ httpx
 python-dotenv
 replicate
 pillow
+requests

--- a/routers/image.py
+++ b/routers/image.py
@@ -1,54 +1,82 @@
 from aiogram import Router, F
-from aiogram.types import Message, BufferedInputFile
+from aiogram.types import Message
 from states import Mode
-
-import replicate
-from io import BytesIO
-from PIL import Image
-
+from config import NANO_BANANA_API_KEY
+import aiohttp
+import asyncio
 
 router = Router()
 
-DEFAULT_IMAGE_PATH = "images/default.jpg"
+GENERATE_URL = "https://api.nanobananaapi.ai/api/v1/nanobanana/generate"
+STATUS_URL = "https://api.nanobananaapi.ai/api/v1/nanobanana/record-info"
+
+
+async def wait_for_image(session, task_id, timeout=60):
+    start = asyncio.get_event_loop().time()
+    
+    while True:
+        async with session.get(
+            f"{STATUS_URL}?taskId={task_id}",
+            headers={"Authorization": f"Bearer {NANO_BANANA_API_KEY}"}
+        ) as resp:
+            data = await resp.json()
+            data_content = data.get("data") or {}        # <- безопасно
+            response = data_content.get("response") or {}  # <- безопасно
+
+            # Если изображение готово — возвращаем URL
+            result_url = response.get("resultImageUrl")
+            if result_url:
+                return result_url
+
+            # Если есть явная ошибка
+            if data_content.get("errorCode"):
+                raise RuntimeError(f"Generation failed: {data_content.get('errorMessage', 'Unknown error')}")
+
+        # Проверка таймаута
+        if asyncio.get_event_loop().time() - start > timeout:
+            raise TimeoutError("Превышено время ожидания генерации изображения")
+
+        await asyncio.sleep(2)
 
 
 @router.message(Mode.image, F.text)
 async def image_handler(message: Message):
+    """
+    Хэндлер для генерации изображения по текстовому промту через Nanobanana.
+    """
     loading_msg = await message.answer("🎨 Генерирую изображение...")
 
     try:
-        result = replicate.run(
-            "google/imagen-4",
-            input={
-                "prompt": message.text,
-                "aspect_ratio": "16:9",
-                "output_format": "jpg",
-                "safety_filter_level": "block_medium_and_above",
-            }
-        )
-        
-        if hasattr(result, "read"):
-            image_bytes = result.read()
-        elif isinstance(result, list):
-            image_bytes = result[0].read() if hasattr(result[0], "read") else result[0]
-        else:
-            image_bytes = result
+        async with aiohttp.ClientSession() as session:
+            # 1️⃣ Создаём задачу генерации
+            async with session.post(
+                GENERATE_URL,
+                headers={
+                    "Authorization": f"Bearer {NANO_BANANA_API_KEY}",
+                    "Content-Type": "application/json"
+                },
+                json={
+                    "prompt": message.text,
+                    "numImages": 1,
+                    "type": "TEXTTOIAMGE",
+                    "image_size": "16:9"
+                }
+            ) as resp:
+                result = await resp.json()
 
-        image = Image.open(BytesIO(image_bytes)).convert("RGB")
+            task_id = result["data"]["taskId"]
 
+            # 2️⃣ Ждём завершения генерации
+            image_url = await wait_for_image(session, task_id, timeout=60)
+
+        # 3️⃣ Отправляем пользователю
+        await message.answer_photo(photo=image_url, caption="🖼 Готово!")
+
+    except TimeoutError:
+        await message.answer("⏱ Превышено время ожидания генерации изображения. Попробуйте снова.")
 
     except Exception as e:
-       image = Image.open(DEFAULT_IMAGE_PATH).convert("RGB")
+        await message.answer(f"❌ Ошибка генерации изображения: {e}")
 
     finally:
-        buffer = BytesIO()
-        image.save(buffer, format="JPEG", quality=90)
-        buffer.seek(0)
-
-        photo = BufferedInputFile(
-            buffer.read(),
-            filename="image.jpg"
-        )
-
-        await message.answer_photo(photo)
         await loading_msg.delete()


### PR DESCRIPTION
### Что сделано
- Заменена модель генерации изображений с Replicate на NanoBanana
- Обновлена логика генерации изображений
- Актуализированы конфигурации и зависимости

### Зачем
- Снижение стоимости генерации изображений (примерно в 2 раза дешевле)
- Улучшение стабильности и предсказуемости работы сервиса
- Подготовка проекта к масштабированию

### Как проверить
- Запустить бота
- Выбрать режим генерации изображения
- Убедиться, что изображение успешно генерируется через NanoBanana API
